### PR TITLE
Add a function for starting up zellij

### DIFF
--- a/config/fish/functions/zat.fish
+++ b/config/fish/functions/zat.fish
@@ -1,0 +1,16 @@
+function zat -d "Start zellij using ./zellij-workspace.kdl for the layout and using the current directory as the session name"
+	# TODO: Override session name with an argument
+	# TODO: Override layout with an argument
+	# TODO:	Don't start a new session inside an existing session
+	# TODO: Attach to existing session
+
+	set --local session_name $(path basename $(pwd))
+	set --local layout_file $(pwd)/zellij-workspace.kdl
+	set --local layout ""
+
+	if test -e $layout_file
+		set layout "-l $layout_file"
+	end
+
+	eval "zellij $layout attach -c $session_name"
+end


### PR DESCRIPTION
Started work on a fish function that starts zellij using the basename of the current working directory as the session name and checks for a zellij-workspace.kdl file to use as the layout. It’s called `zat`, based on Chris Toomey’s tat function for tmux.